### PR TITLE
Fix Readme: Change dev to development

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ $ docker-compose logs --tail 100 -f production
 
 Start development enviroment 
 ```console
-$ docker-compose up dev
+$ docker-compose up development
 ```
 
 Re-building docker


### PR DESCRIPTION
Amazing project! The only thing is that this line should be "development". Because at least in my case, docker-compose doesn't recognize dev.